### PR TITLE
Fix publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,6 @@ gem 'dotenv-rails'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'capybara', '~> 2.13'
-  gem 'cucumber-rails'
-  gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
@@ -43,6 +41,12 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
 end
+
+group :test do
+  gem 'cucumber-rails', require: false
+  gem 'database_cleaner'
+end
+
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 [![Code Climate](https://codeclimate.com/github/flyinggrizzly/s301/badges/gpa.svg)](https://codeclimate.com/github/flyinggrizzly/s301)
 [![Build Status](https://travis-ci.org/flyinggrizzly/s301.svg?branch=master)](https://travis-ci.org/flyinggrizzly/s301)
 
-**Heads up, this isn't quite ready for use yet! The parts work in isolation, but I seem to have broken the connection between the ShortUrl model and the Publishing service... serves me right for not havign a test harness set up first!**
-
 S301 is intended to be a lightweight, fast, and resilient URL shortener. It uses AWS' S3 and Cloudfront in ways typically intended for hosting static websites, to expose redirects at any Cloudfront edge location.
 
 The Rails app manages all known short URLs, and when changes are made, they are published out to an S3 bucket, and the Cloudfront cache is invalidated. Instead of static HTML objects being stored in the S3 bucket, S301 stores itty-bitty files with two important pieces of information: the name, which is your short URL slug, and an [`x-amz-website-redirect-location` metadatum](https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#how-to-page-redirect), which is interpreted as the destination in a 301 redirect.

--- a/spec/services/redirect_publisher_service/aws_publisher_spec.rb
+++ b/spec/services/redirect_publisher_service/aws_publisher_spec.rb
@@ -2,26 +2,13 @@ require 'rails_helper'
 
 RSpec.describe RedirectPublisherService::AwsPublisher do
 
-  before(:each, stub_aws_connection: true) do
-    stub_s3_client
-    stub_cloudfront_client
-  end
-
   describe 'public interface' do
-    before(:each, stub_s3_client: true) do
-      stub_s3_client
-    end
-
-    before(:each, stub_cloudfront_client: true) do
-      stub_cloudfront_client
-    end
-
-    it 'responds to #publish', :stub_s3_client do
+    it 'responds to #publish' do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :publish
     end
 
-    it 'responds to #unpublish', :stub_s3_client do
+    it 'responds to #unpublish' do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :unpublish
     end
@@ -38,7 +25,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
   end
 
   describe '#publish' do
-    it 'requires as a parameter a hash of short URL params [:slug, :redirect]', :stub_aws_connection, :aggregate_failures do
+    it 'requires as a parameter a hash of short URL params [:slug, :redirect]', :aggregate_failures do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect {
@@ -50,7 +37,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
       aws_publisher.publish({ slug: 'foo', redirect: 'http://www.example.com' }, :new)
     end
 
-    it 'requires a publication_type parameter', :stub_aws_connection, :aggregate_failures do
+    it 'requires a publication_type parameter', :aggregate_failures do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       short_url_hash = { slug: 'foo', redirect: 'http://www.example.com' }
@@ -66,7 +53,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
       aws_publisher.publish(short_url_hash, :changed)
     end
 
-    it 'sends a put_object request to S3 for new short URLs', :stub_aws_connection do
+    it 'sends a put_object request to S3 for new short URLs' do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:put_object)
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
@@ -77,7 +64,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
       aws_publisher.publish({ slug: 'foo', redirect: 'http://www.example.com' }, :new)
     end
 
-    it 'sends a copy_object request to S3 for updated short URLs', :stub_aws_connection do
+    it 'sends a copy_object request to S3 for updated short URLs' do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:copy_object)
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
@@ -88,7 +75,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
       aws_publisher.publish({ slug: 'foo', redirect: 'http://www.example.com' }, :changed)
     end
 
-    it 'invalidates the cloudfront cache for the slug', :stub_aws_connection do
+    it 'invalidates the cloudfront cache for the slug' do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate)
@@ -98,7 +85,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
   end
 
   describe '#unpublish' do
-    it 'sends a destroy_object request to S3', :stub_aws_connection do
+    it 'sends a destroy_object request to S3' do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:delete_object).and_return(true)
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
@@ -109,7 +96,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
       aws_publisher.unpublish(slug: 'foo', redirect: 'http://www.example.com')
     end
 
-    it 'invalidates the cloudfront cache for the slug', :stub_aws_connection do
+    it 'invalidates the cloudfront cache for the slug' do
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate)
@@ -119,7 +106,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
   end
 
   describe '#cloudfront_invalidate' do
-    it 'sends a create_invalidation request to Cloudfront', :stub_aws_connection do
+    it 'sends a create_invalidation request to Cloudfront' do
       cloudfront = instance_double(Aws::CloudFront::Client)
       expect(cloudfront).to receive(:create_invalidation)
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
@@ -130,26 +117,10 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
   end
 
   describe '#cloudfront_invalidate_all' do
-    it 'calls #cloudfront_invalidate with a wildcard parameter', :stub_aws_connection do
+    it 'calls #cloudfront_invalidate with a wildcard parameter' do
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate).with('*')
       aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       aws_publisher.cloudfront_invalidate_all
     end
-  end
-
-  private
-
-  def stub_s3_client
-    s3_client = instance_double(Aws::S3::Client)
-    s3_client_class = class_double(Aws::S3::Client)
-    allow(s3_client_class).to receive(:new)
-      .and_return(s3_client)
-  end
-
-  def stub_cloudfront_client
-    cloudfront_client = instance_double(Aws::CloudFront::Client)
-    cloudfront_client_class = class_double(Aws::CloudFront::Client)
-    allow(cloudfront_client_class).to receive(:new)
-      .and_return(cloudfront_client)
   end
 end

--- a/spec/services/redirect_publisher_service/aws_publisher_spec.rb
+++ b/spec/services/redirect_publisher_service/aws_publisher_spec.rb
@@ -17,29 +17,29 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     end
 
     it 'responds to #publish', :stub_s3_client do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :publish
     end
 
     it 'responds to #unpublish', :stub_s3_client do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :unpublish
     end
 
     it 'responds to #cloudfront_invalidate', :stub_cloudfront_client do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :cloudfront_invalidate
     end
 
     it 'responds to #cloudfront_invalidate_all', :stub_cloudfront_client do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       expect(aws_publisher).to respond_to :cloudfront_invalidate_all
     end
   end
 
   describe '#publish' do
     it 'requires as a parameter a hash of short URL params [:slug, :redirect]', :stub_aws_connection, :aggregate_failures do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect {
         aws_publisher.publish({}, :new)
@@ -51,7 +51,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     end
 
     it 'requires a publication_type parameter', :stub_aws_connection, :aggregate_failures do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       short_url_hash = { slug: 'foo', redirect: 'http://www.example.com' }
       expect {
@@ -69,7 +69,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     it 'sends a put_object request to S3 for new short URLs', :stub_aws_connection do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:put_object)
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       # Inject spy
       aws_publisher.instance_variable_set(:@s3, s3)
@@ -80,7 +80,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     it 'sends a copy_object request to S3 for updated short URLs', :stub_aws_connection do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:copy_object)
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       # Inject spy
       aws_publisher.instance_variable_set(:@s3, s3)
@@ -89,7 +89,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     end
 
     it 'invalidates the cloudfront cache for the slug', :stub_aws_connection do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate)
 
@@ -101,7 +101,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     it 'sends a destroy_object request to S3', :stub_aws_connection do
       s3 = instance_double(Aws::S3::Client)
       expect(s3).to receive(:delete_object).and_return(true)
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       # Inject spy
       aws_publisher.instance_variable_set(:@s3, s3)
@@ -110,7 +110,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     end
 
     it 'invalidates the cloudfront cache for the slug', :stub_aws_connection do
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate)
 
@@ -122,7 +122,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     it 'sends a create_invalidation request to Cloudfront', :stub_aws_connection do
       cloudfront = instance_double(Aws::CloudFront::Client)
       expect(cloudfront).to receive(:create_invalidation)
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
 
       aws_publisher.instance_variable_set(:@cloudfront, cloudfront)
       aws_publisher.cloudfront_invalidate('foo')
@@ -132,7 +132,7 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
   describe '#cloudfront_invalidate_all' do
     it 'calls #cloudfront_invalidate with a wildcard parameter', :stub_aws_connection do
       expect_any_instance_of(RedirectPublisherService::AwsPublisher).to receive(:cloudfront_invalidate).with('*')
-      aws_publisher = RedirectPublisherService::AwsPublisher.new
+      aws_publisher = RedirectPublisherService::AwsPublisher.new(stub_responses: true)
       aws_publisher.cloudfront_invalidate_all
     end
   end

--- a/spec/services/redirect_publisher_service_spec.rb
+++ b/spec/services/redirect_publisher_service_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RedirectPublisherService do
   end
 
   it 'includes an AWS publisher' do
+    expect(RedirectPublisherService::AwsPublisher).to be_an_instance_of(Class)
   end
 
   describe '::publish' do
@@ -81,7 +82,7 @@ RSpec.describe RedirectPublisherService do
     end
 
     it 'sends a message to the selected publisher to unpublish a short URL' do
-      pending "implicitly tested by other ::publish specs, don't implement until there are other publishers"
+      pending "implicitly tested by other ::unpublish specs, don't implement until there are other publishers"
       expect(true).to eq(false)
     end
   end


### PR DESCRIPTION
Fixes a dumb `case` statement mistake, and removes mention of Rails' test environment in code.

Cleans up `RedirectPublisherService` and `RedirectPublisherService::AwsPublisher` specs and removes their dependency on an accessible network