### PR TITLE
Fix caching

### DIFF
--- a/app/models/short_url.rb
+++ b/app/models/short_url.rb
@@ -12,34 +12,25 @@ class ShortUrl < ApplicationRecord
   after_save     :publish
   before_destroy :unpublish
 
-  def self.publish(short_url)
-    slug, redirect = validate_and_assign_publication_args_for short_url
-    RedirectPublisherService.publish(slug: slug, redirect: redirect)
+  def self.publish(short_url = nil)
+    RedirectPublisherService.publish(ShortUrl.all)
+    slug_to_invalidate = short_url ? short_url.slug : '*'
+    RedirectPublisherService.invalidate_cdn_cache_for slug_to_invalidate
   end
 
   def self.unpublish(short_url)
-    slug, redirect = validate_and_assign_publication_args_for short_url
-    RedirectPublisherService.unpublish(slug)
-  end
-
-  private_class_method def self.validate_and_assign_publication_args_for(short_url)
-    # Case behaves strangely with .class--call directly against object
-    # see https://stackoverflow.com/questions/948135/how-to-write-a-switch-statement-in-ruby#answer-5694333
-    case short_url
-    when ShortUrl
-      [short_url.slug, short_url.redirect]
-    when Hash
-      raise ArgumentError, 'hash keys must be :slug and :redirect' unless short_url.keys.sort.eql? %i[redirect slug]
-      [short_url[:slug], short_url[:redirect]]
-    else
-      raise ArgumentError, 'Expected a Hash or ShortUrl object'
-    end
+    extant_short_urls = ShortUrl.all - [short_url]
+    RedirectPublisherService.publish(extant_short_urls)
+    RedirectPublisherService.invalidate_cdn_cache_for short_url.slug
   end
 
   private
 
   def publish
     ShortUrl.publish(itself)
+  rescue StandardError
+    flash[:error] = 'Short URL could not be published'
+    throw :abort
   end
 
   def unpublish

--- a/lib/redirect_publisher_service.rb
+++ b/lib/redirect_publisher_service.rb
@@ -4,31 +4,13 @@ require 'redirect_publisher_service/aws_publisher'
 module RedirectPublisherService
   # Accepts a hash { slug: 'slug', redirect: 'http://www.example.com' } and
   # a publication type, either :new or :changed
-  def self.publish(short_url = {}, publisher = nil)
-    raise_unless_short_url_parameters_valid(short_url)
-
+  def self.publish(short_urls = {}, publisher = nil)
     publisher ||= AwsPublisher.new
-    publisher.publish(short_url)
+    publisher.publish_redirects_for(short_urls)
   end
 
-  # Accepts a hash { slug: 'slug', redirect: 'http://www.example.com' }
-  def self.unpublish(slug)
-    aws_publisher = AwsPublisher.new
-    aws_publisher.unpublish(slug)
+  def self.invalidate_cdn_cache_for(slug, publisher = nil)
+    publisher ||= AwsPublisher.new
+    publisher.create_cloudfront_invalidation_for slug
   end
-
-  private_class_method def self.short_url_vals_not_blank(short_url)
-    short_url.each_value do |v|
-      return false if v.blank?
-    end
-  end
-
-  private_class_method def self.raise_unless_short_url_parameters_valid(short_url)
-    msg = 'short URLs cannot be published without both slug and redirect'
-    raise msg unless short_url.keys.sort.eql? %i[redirect slug]
-    raise msg unless short_url_vals_not_blank(short_url)
-  end
-
-  # Available publishers (defined in lib/redirect_publisher_service/*_publisher.rb)
-  class AwsPublisher; end
 end

--- a/lib/redirect_publisher_service/aws_publisher.rb
+++ b/lib/redirect_publisher_service/aws_publisher.rb
@@ -1,6 +1,7 @@
 module RedirectPublisherService
   # Provides methods for interacting with AWS S3 and Cloudfront
   class AwsPublisher
+    require 'addressable'
     require 'aws-sdk-cloudfront'
     require 'aws-sdk-s3'
 
@@ -14,20 +15,19 @@ module RedirectPublisherService
       @cloudfront    = cloudfront_client unless @distro_id.nil?
     end
 
+    # Convenience constructor for creating a test object that uses the AWS SDK response stubs
     def self.new_with_stubbed_responses
       new(stub_responses: true)
     end
 
-    def publish(short_url_data)
-      validate short_url_data
-      put_s3_object_for short_url_data
-      create_cloudfront_invalidation_for short_url_data[:slug]
+    def define_bucket_redirect_rules_for(short_urls)
+      config = s3_bucket_site_config_with(short_urls)
+      @s3.put_bucket_website(
+        bucket: @bucket,
+        website_configuration: config
+      )
     end
-
-    def unpublish(slug)
-      delete_s3_object_for slug
-      create_cloudfront_invalidation_for slug
-    end
+    alias publish_redirects_for define_bucket_redirect_rules_for
 
     def create_cloudfront_invalidation_for(slug)
       return unless @distro_id
@@ -44,38 +44,27 @@ module RedirectPublisherService
 
     private
 
-    def put_s3_object_for(short_url_data)
-      tries ||= 3
-      @s3.put_object(bucket:                    @bucket,
-                     key:                       short_url_data[:slug],
-                     cache_control:             s3_object_cache_control_headers,
-                     website_redirect_location: short_url_data[:redirect])
-    rescue Aws::S3::Errors
-      retry unless (tries -= 1).zero?
-    end
-
-    def delete_s3_object_for(key)
-      tries ||= 3
-      @s3.delete_object(bucket: @bucket,
-                        key:    key)
-    rescue Aws::S3::Errors
-      retry unless (tries -= 1).zero?
-    end
-
-    def validate(params)
-      msg = 'requires a Hash with :slug and :redirect as parameters'
-      raise(ArgumentError, msg) unless params.class.eql?(Hash) && params.keys.sort.eql?(%i[redirect slug])
-    end
-
     def object_path(slug)
       "/#{slug}"
     end
 
-    def s3_object_cache_control_headers
-      time_a_browser_should_cache = 'max-age=0'
-      time_cloudfront_should_cache = "s-maxage=#{ONE_YEAR_IN_SECONDS}"
+    def s3_bucket_site_config_with(short_urls)
+      config = {
+        error_document: { key: 'unknown-short-url' },
+        index_document: { suffix: 'index' },
+      }
+      config.merge(routing_rules: generate_redirect_rules_hash_for(short_urls)) if short_urls.first
+    end
 
-      "#{time_a_browser_should_cache} #{time_cloudfront_should_cache}"
+    def generate_redirect_rules_hash_for(short_urls)
+      short_urls.map do |short_url|
+        redirect = Addressable::URI.heuristic_parse(short_url.redirect)
+        { condition: { key_prefix_equals: short_url.slug },
+          redirect: { host_name: redirect.host,
+                      replace_key_with: redirect.path,
+                      protocol: redirect.scheme,
+                      http_redirect_code: '307' } }
+      end
     end
 
     def s3_client

--- a/lib/redirect_publisher_service/aws_publisher.rb
+++ b/lib/redirect_publisher_service/aws_publisher.rb
@@ -5,8 +5,6 @@ module RedirectPublisherService
     require 'aws-sdk-cloudfront'
     require 'aws-sdk-s3'
 
-    ONE_YEAR_IN_SECONDS = 31536000
-
     def initialize(client_params = nil)
       @bucket        = ENV['AWS_S3_BUCKET_NAME']
       @distro_id     = ENV['AWS_CLOUDFRONT_DISTRO_ID'] || nil

--- a/spec/models/short_url_spec.rb
+++ b/spec/models/short_url_spec.rb
@@ -40,20 +40,22 @@ RSpec.describe ShortUrl, type: :model do
   end
 
   describe 'class methods' do
-    specify '::publish sends a message to the PublisherService to publish a resource' do
-      publisher_service = object_double(RedirectPublisherService).as_stubbed_const
-      expect(publisher_service).to receive(:publish)
-        .with(slug: 'sluggy-mc-slugface', redirect: 'http://www.example.com')
-
-      ShortUrl.publish(slug: 'sluggy-mc-slugface', redirect: 'http://www.example.com')
+    describe '::publish' do
+      it 'sends all existing short URLs to the RedirectPublisherService and requests a CDN invalidation for the updated or created short URL' do
+        su = ShortUrl.new(slug: 'slug', redirect: 'http://www.example.com')
+        publisher_service = object_double(RedirectPublisherService).as_stubbed_const
+        expect(publisher_service).to receive(:publish).with(ShortUrl.all)
+        expect(publisher_service).to receive(:invalidate_cdn_cache_for).with('slug')
+        ShortUrl.publish(su)
+      end
     end
 
-    specify '::unpublish sends a message to the PublisherService to unpublish a resource' do
+    specify '::unpublish sends a message to the PublisherService to republish remaining short URLs' do
+      su = ShortUrl.new(slug: 'sluggy-unpublish-face', redirect: 'http://www.example.com')
       publisher_service = object_double(RedirectPublisherService).as_stubbed_const
-      expect(publisher_service).to receive(:unpublish)
-        .with('sluggy-unpublish-face')
-
-      ShortUrl.unpublish(slug: 'sluggy-unpublish-face', redirect: 'http://www.example.com')
+      expect(publisher_service).to receive(:publish)
+      expect(publisher_service).to receive(:invalidate_cdn_cache_for)
+      ShortUrl.unpublish(su)
     end
   end
 end

--- a/spec/services/redirect_publisher_service/aws_publisher_spec.rb
+++ b/spec/services/redirect_publisher_service/aws_publisher_spec.rb
@@ -1,16 +1,15 @@
 require 'rails_helper'
 require 'nokogiri/xml'
+require 'redirect_publisher_service'
 
 RSpec.describe RedirectPublisherService::AwsPublisher do
 
   describe 'public interface' do
     let(:aws_publisher) { described_class.new_with_stubbed_responses }
-    it 'responds to #publish' do
-      expect(aws_publisher).to respond_to :publish
-    end
 
-    it 'responds to #unpublish' do
-      expect(aws_publisher).to respond_to :unpublish
+    it 'responds to #publish_redirects_for' do
+      expect(aws_publisher).to respond_to :publish_redirects_for
+      expect(aws_publisher.method(:publish_redirects_for)).to eq aws_publisher.method(:define_bucket_redirect_rules_for)
     end
 
     it 'responds to #create_cloudfront_invalidation_for' do
@@ -22,27 +21,14 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
     end
   end
 
-  describe '#publish' do
+  describe '#publish_redirects_for' do
     let(:aws_publisher) { described_class.new }
-    it 'sends a put request to S3 and invalidates the CloudFront cache when provided with a slug and URL' do
-      expect(aws_publisher).to receive(:create_cloudfront_invalidation_for).with('foo')
-      WebMock.stub_request(:put, s3_url_for('foo'))
-
-      send_publish_message_for(slug: 'foo', redirect: 'http://www.example.com')
-
-      expect(WebMock).to have_requested(:put, s3_url_for('foo'))
-        .with(headers: {
-                'X-Amz-Website-Redirect-Location' => 'http://www.example.com'
-              })
-    end
-  end
-
-  describe '#unpublish' do
-    let(:aws_publisher) { described_class.new }
-    it 'sends a delete request to S3 and invalidates the CloudFront cache' do
-      expect(aws_publisher).to receive(:create_cloudfront_invalidation_for).with('foo')
-      send_unpublish_message_for 'foo'
-      expect(WebMock).to have_requested(:delete, s3_url_for('foo'))
+    it 'sends a PUT request to configure the bucket with redirects and index and error documents' do
+      WebMock.stub_request(:put, "https://#{ENV['AWS_S3_BUCKET_NAME']}.s3.amazonaws.com/?website")
+      aws_publisher.publish_redirects_for([ShortUrl.new(slug: 'da-slug', redirect: 'http://www.example.com'),
+                                           ShortUrl.new(slug: 'da-slug-2', redirect: 'http://www.example.com')])
+      expect(WebMock).to have_requested(:put, "https://#{ENV['AWS_S3_BUCKET_NAME']}.s3.amazonaws.com/?website")
+        .with { |req| req.body == bucket_config_update_request_body }
     end
   end
 
@@ -87,5 +73,42 @@ RSpec.describe RedirectPublisherService::AwsPublisher do
 
   def cloudfront_url
     'https://cloudfront.amazonaws.com/2017-03-25/distribution/IAMCLOUDFRONT111/invalidation'
+  end
+
+  def bucket_config_update_request_body
+    <<~REQUEST_BODY
+      <WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <ErrorDocument>
+          <Key>unknown-short-url</Key>
+        </ErrorDocument>
+        <IndexDocument>
+          <Suffix>index</Suffix>
+        </IndexDocument>
+        <RoutingRules>
+          <RoutingRule>
+            <Condition>
+              <KeyPrefixEquals>da-slug</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+              <HostName>www.example.com</HostName>
+              <HttpRedirectCode>307</HttpRedirectCode>
+              <Protocol>http</Protocol>
+              <ReplaceKeyWith></ReplaceKeyWith>
+            </Redirect>
+          </RoutingRule>
+          <RoutingRule>
+            <Condition>
+              <KeyPrefixEquals>da-slug-2</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+              <HostName>www.example.com</HostName>
+              <HttpRedirectCode>307</HttpRedirectCode>
+              <Protocol>http</Protocol>
+              <ReplaceKeyWith></ReplaceKeyWith>
+            </Redirect>
+          </RoutingRule>
+        </RoutingRules>
+      </WebsiteConfiguration>
+    REQUEST_BODY
   end
 end

--- a/spec/services/redirect_publisher_service_spec.rb
+++ b/spec/services/redirect_publisher_service_spec.rb
@@ -1,19 +1,38 @@
 require 'rails_helper'
+require 'redirect_publisher_service'
 
 WebMock.disable_net_connect!(allow_local_host: true)
 
 RSpec.describe RedirectPublisherService do
   describe 'public interface' do
     it 'responds to ::publish' do
-      expect(RedirectPublisherService).to respond_to(:publish)
+      expect(described_class).to respond_to :publish
     end
 
-    it 'responds to ::unpublish' do
-      expect(RedirectPublisherService).to respond_to(:unpublish)
+    it 'responds to ::invalidate_cdn_cache_for' do
+      expect(described_class).to respond_to :invalidate_cdn_cache_for
+    end
+  end
+
+  describe '::publish' do
+    let(:aws_publisher) { described_class::AwsPublisher.new_with_stubbed_responses }
+    it 'sends a message to the publisher with a batch of short URLs' do
+      short_urls = [ShortUrl.new(slug: 'da-slug', redirect: 'http://www.example.com'),
+                    ShortUrl.new(slug: 'go-slug', redirect: 'http://www.example.com')]
+      expect(aws_publisher).to receive(:publish_redirects_for).with(short_urls)
+      described_class.publish(short_urls, aws_publisher)
+    end
+  end
+
+  describe '::invalidate_cdn_cache_for' do
+    let(:aws_publisher) { described_class::AwsPublisher.new_with_stubbed_responses }
+    it 'sends a message to the publisher with a slug' do
+      expect(aws_publisher).to receive(:create_cloudfront_invalidation_for).with('sluggy')
+      described_class.invalidate_cdn_cache_for('sluggy', aws_publisher)
     end
   end
 
   it 'includes an AWS publisher' do
-    expect(RedirectPublisherService::AwsPublisher).to be_an_instance_of(Class)
+    expect(described_class::AwsPublisher).to be_an_instance_of(Class)
   end
 end


### PR DESCRIPTION
The application was hving a problem where, while redirects were being updated, and the right headers were being set on them, those headers were not being passed on to clients. This resulted in browsers caching responses, regardless of invalidation.

This PR changes the S3 strategy to set all redirects directly in the bucket config, rather than on each object.

It's less clean and requires thta all redirects be updated whenever one changes, but the size the PUT request is still friggin' tiny. We shall survive.